### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn run test:unit"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # README!
 
+[![Run on Repl.it](https://repl.it/badge/github/replit/audio-js)](https://repl.it/github/replit/audio-js)
+
 This is a boilerplate for typescript packages. Find and replace "`somepackage`" with the name of your package.
 
 ✔️ Compiles your package into commonjs using the typescript compiler - `yarn build`


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).
