### PR TITLE
Fix None usage

### DIFF
--- a/python/replit/__init__.py
+++ b/python/replit/__init__.py
@@ -423,7 +423,7 @@ class Audio():
         '''
         with open('/tmp/audioStatus.json', 'r') as f:
             data = AudioStatus(json.loads(f.read()))
-            if data['Sources'] == None:
+            if data['Sources'] is None:
                 data['Sources']: List[SourceData] = []
             return data
 


### PR DESCRIPTION
Using `==` is not always a clever idea when dealing with `None`'s, for example, if you have this class:
`class NotNone: __eq__ = lambda self, other: True`
Then `NotNone()==None` returns True
But `NonNone() is None` returns False

And PEP 8 says: 
> Comparisons to singletons like None should always be done with 'is' or 'is not', NEVER the equality operators.